### PR TITLE
Custom Set View Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Block::make('My beautiful block', 'my_beautiful_block')
     ->setIcon('editor-code')
     ->setAlign('wide')
     ->enableJsx()
-    ->setView('partials.my-beautiful-block');
+    ->setView('partials.my-beautiful-block', [
+        'key' => 'value',
+    ]);
 ```
 
 ### Rendering a block
@@ -78,6 +80,7 @@ Block::make('My beautiful block', 'my_beautiful_block')
 
 ```php
 <div class="p-4">
+    <?php var_dump($viewData); ?>
     <h1><?php echo $field->title; ?></h1>
     <p><?php echo $field->content; ?></p>
     <?php echo $innerBlocks ?>
@@ -90,6 +93,7 @@ Block::make('My beautiful block', 'my_beautiful_block')
 <div class="p-4">
     <h1>{{$field->title}}</h1>
     <p>{{$field->content}}</p>
+    <p>{{$viewData['key']}}</p>
     {!! $innerBlocks !!}
 </div>
 ```

--- a/src/Block.php
+++ b/src/Block.php
@@ -71,6 +71,7 @@ class Block
                 $viewArgs = [
                     'block' => $block,
                     'instance' => $this,
+                    'viewData' => $this->getViewData(),
                 ];
 
                 $viewArgs['innerBlocks'] = '';

--- a/src/Traits/Template.php
+++ b/src/Traits/Template.php
@@ -5,6 +5,7 @@ namespace AmphiBee\AcfBlocks\Traits;
 trait Template
 {
     protected $renderTemplate;
+    protected array $viewData = [];
     
     /**
      * Set the render template
@@ -27,13 +28,34 @@ trait Template
     }
 
     /**
+     * Set the view data
+     * @param array $data Data to pass to the view
+     * @return $this
+     */
+    public function setViewData(array $data): self
+    {
+        $this->viewData = $data;
+        return $this;
+    }
+
+    /**
+     * Get the view data
+     * @return array
+     */
+    public function getViewData(): array
+    {
+        return $this->viewData;
+    }
+
+    /**
      * Shortcut for setRenderTemplate (More Blade friendly)
      * @param string $renderTemplate Path to the render template (blade path)
      * @return $this
      */
-    public function setView(string $view): self
+    public function setView(string $view, array $data = []): self
     {
         $this->setRenderTemplate($view);
+        $this->setViewData($data);
         return $this;
     }
 


### PR DESCRIPTION
### New feature: Custom Set View Options

#### Description
I have added a new feature that allows users to add custom elements to the setView method in the ACF Blocks plugin.

#### Usage Example
```php
->setView('partials.my-beautiful-block', [
    'key' => 'value',
]);
```

This enhancement provides greater flexibility in customizing views for ACF Blocks, allowing developers to pass additional data as needed.

#### Changes Made
I modified the setView method to accept an optional associative array of key-value pairs, allowing developers to include custom data when defining the view path.

I hope this addition is beneficial to the project and will improve the development experience for users.